### PR TITLE
First version of sagemaker train wrapper

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,0 +1,13 @@
+SM_MODEL_DIR="data/sm/model/"
+SM_OUTPUT_DIR="data/sm/output/"
+SM_CHECKPOINT_DIR="data/sm/checkpoints/"
+
+YOLO_IMGSZ=128
+YOLO_BATCH_SIZE=32
+YOLO_WEIGHTS="yolov5n.pt"
+
+YOLO_DATA="data/yolo_export/Taxonomie_Baum/Taxonomie_Baum_local.yaml"
+YOLO_HYP="data/yolo_export/Taxonomie_Baum/hyp.yaml"
+YOLO_PROJECT="data/sm/checkpoints/"
+YOLO_NAME="Taxonomie_Baum_resume"
+YOLO_SAVE_PERIOD=-1

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,5 @@ thop>=0.1.1  # FLOPs computation
 cloudpathlib
 boto3
 s3fs
+sagemaker-ssh-helper==1.7.8
+environs==9.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,8 +47,8 @@ thop>=0.1.1  # FLOPs computation
 # roboflow
 
 # Custom -------------
-cloudpathlib
-boto3
-s3fs
-sagemaker-ssh-helper==1.7.8
+cloudpathlib==0.10.0
+boto3==1.24.78
+s3fs==0.4.2
 environs==9.5.0
+sagemaker-ssh-helper==1.7.8

--- a/train_sagemaker.py
+++ b/train_sagemaker.py
@@ -1,9 +1,10 @@
-import os
-import argparse
+from pathlib import Path
+import shutil
 
-import yolov5.train
 import environs
 import sagemaker_ssh_helper
+
+import train
 
 if __name__ == "__main__":
     # Runs ssh helper (configured by estimator launch code)
@@ -13,30 +14,44 @@ if __name__ == "__main__":
     # Env
     ############################################
 
-    env_args: dict[str, str] = {}
+    env_args: dict = {}
     env = environs.Env()
-    env.read_env()
+    # env.read_env() # read .env file, not needed in sagemaker env
 
     # Sagemaker env variables
     with env.prefixed("SM_"):
-        env_args["model_dir"] = env.path("MODEL_DIR", "/opt/ml/model/")
-        env_args["output_dir"] = env.path("OUTPUT_DIR", "/opt/ml/output/")
-        env_args["checkpoint_dir"] = env.path("CHECKPOINT_DIR", "/opt/ml/checkpoints/")
+        dataset_path = env.path("CHANNEL_YOLO_DATASET")
+        model_dir = env.path("MODEL_DIR")
+        output_data_dir = env.path("OUTPUT_DATA_DIR")
 
     # Yolov5 arguments
     with env.prefixed("YOLO_"):
-        env_args["imgsz"] = env.int("IMGSZ", 512)
-        env_args["batch_size"] = env.int("BATCH", 32)
-        env_args["weights"] = env.str("WEIGHTS")
-        env_args["data"] = env.path("DATA")
-        env_args["hyp"] = env.path("HYP")
-        env_args["project"] = env.path("PROJECT", "/opt/ml/runs/")
+        env_args["data"] = dataset_path / env.path("DATASET_FILE")
+        env_args["hyp"] = dataset_path / env.path("HYP_FILE")
+        # TODO maybe SAGEMAKER_JOB_NAME works across spot restarts?
+        env_args["project"] = env.path("PROJECT")
         env_args["name"] = env.str("NAME")
+        # overwrite any existing output
+        env_args["exist_ok"] = True
         env_args["save_period"] = env.int("SAVE_PERIOD", -1)
 
-    opt = yolov5.train.parse_opt(True)
+        # only resume if the file exists
+        resume_path = env.path("RESUME_PATH")
+        if resume_path.exists():
+            env_args['resume'] = str(resume_path)
+
+    opt = train.parse_opt(True)
     for key, val in env_args.items():
         setattr(opt, key, val)
 
-    print(opt)
-    yolov5.train.main(opt)
+    train.main(opt)
+
+    src = resume_path.parent / 'best.pt'
+    dst = model_dir
+    print(f"Copy {src} to {dst}")
+    shutil.copy2(src, dst)
+
+    src = env_args["project"] / env_args['name']
+    dst = output_data_dir
+    print(f"Copy {src} to {dst}")
+    shutil.copytree(src, dst, dirs_exist_ok=True)

--- a/train_sagemaker.py
+++ b/train_sagemaker.py
@@ -1,0 +1,42 @@
+import os
+import argparse
+
+import yolov5.train
+import environs
+import sagemaker_ssh_helper
+
+if __name__ == "__main__":
+    # Runs ssh helper (configured by estimator launch code)
+    sagemaker_ssh_helper.setup_and_start_ssh()
+
+    ############################################
+    # Env
+    ############################################
+
+    env_args: dict[str, str] = {}
+    env = environs.Env()
+    env.read_env()
+
+    # Sagemaker env variables
+    with env.prefixed("SM_"):
+        env_args["model_dir"] = env.path("MODEL_DIR", "/opt/ml/model/")
+        env_args["output_dir"] = env.path("OUTPUT_DIR", "/opt/ml/output/")
+        env_args["checkpoint_dir"] = env.path("CHECKPOINT_DIR", "/opt/ml/checkpoints/")
+
+    # Yolov5 arguments
+    with env.prefixed("YOLO_"):
+        env_args["imgsz"] = env.int("IMGSZ", 512)
+        env_args["batch_size"] = env.int("BATCH", 32)
+        env_args["weights"] = env.str("WEIGHTS")
+        env_args["data"] = env.path("DATA")
+        env_args["hyp"] = env.path("HYP")
+        env_args["project"] = env.path("PROJECT", "/opt/ml/runs/")
+        env_args["name"] = env.str("NAME")
+        env_args["save_period"] = env.int("SAVE_PERIOD", -1)
+
+    opt = yolov5.train.parse_opt(True)
+    for key, val in env_args.items():
+        setattr(opt, key, val)
+
+    print(opt)
+    yolov5.train.main(opt)


### PR DESCRIPTION
- Locally, copy env.template to .env and change values
- YOLO prefixed env variables get manually mapped to parameters
  - [ ] Maybe make this generic, without manual mapping
- Runs SSH helper, which correctly no-ops locally